### PR TITLE
Fix CI Linux ARM64 Build

### DIFF
--- a/.github/workflows/ci-validation.yml
+++ b/.github/workflows/ci-validation.yml
@@ -66,7 +66,12 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev
+          if [ "${{ matrix.name }}" = "ARM64" ]; then
+            chmod +x scripts/setup_linux_arm64_deps.sh
+            ./scripts/setup_linux_arm64_deps.sh
+          else
+            sudo apt-get install -y libcurl4-openssl-dev
+          fi
 
       - name: Run Kotlin Unit Tests
         if: matrix.name == 'x64'

--- a/.github/workflows/ci-validation.yml
+++ b/.github/workflows/ci-validation.yml
@@ -69,6 +69,11 @@ jobs:
           if [ "${{ matrix.name }}" = "ARM64" ]; then
             chmod +x scripts/setup_linux_arm64_deps.sh
             ./scripts/setup_linux_arm64_deps.sh
+            
+            # Find libgcc.a path for ARM64 cross-compiler
+            LIBGCC_PATH=$(find /usr/lib/gcc-cross/aarch64-linux-gnu -name libgcc.a | head -n 1)
+            echo "LIBGCC_PATH=$LIBGCC_PATH" >> $GITHUB_ENV
+            echo "Found libgcc.a at: $LIBGCC_PATH"
           else
             sudo apt-get install -y libcurl4-openssl-dev
           fi

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
                 baseName = "barbatos"
                 linkerOpts(
                     "-L/usr/lib/aarch64-linux-gnu",
-                    "-L/usr/lib/gcc-cross/aarch64-linux-gnu/13",
+                    "-L/usr/aarch64-linux-gnu/lib",
                     "--allow-shlib-undefined",
                     "-lssl", "-lcrypto",
                     "-lssh",
@@ -36,7 +36,7 @@ kotlin {
                     "-lrtmp",
                     "-lzstd",
                     "-lz",
-                    "/usr/lib/gcc-cross/aarch64-linux-gnu/13/libgcc.a"
+                    "-lgcc"
                 )
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
             executable {
                 entryPoint = "main"
                 baseName = "barbatos"
+                val libgccPath = System.getenv("LIBGCC_PATH")
                 linkerOpts(
                     "-L/usr/lib/aarch64-linux-gnu",
                     "-L/usr/aarch64-linux-gnu/lib",
@@ -36,7 +37,7 @@ kotlin {
                     "-lrtmp",
                     "-lzstd",
                     "-lz",
-                    "-lgcc"
+                    if (libgccPath != null && libgccPath.isNotEmpty()) libgccPath else "-lgcc"
                 )
             }
         }


### PR DESCRIPTION
This PR fixes the `linkDebugExecutableLinuxArm64` failure in CI by:
1. Updating `ci-validation.yml` to install required ARM64 cross-compilation dependencies using `scripts/setup_linux_arm64_deps.sh`.
2. Updating `build.gradle.kts` to use more flexible linker paths and avoid hardcoded GCC versions.