### PR TITLE
feat: add interactive device selection on debug command

### DIFF
--- a/src/commonMain/kotlin/AdbDeviceManager.kt
+++ b/src/commonMain/kotlin/AdbDeviceManager.kt
@@ -1,0 +1,69 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+import platform.posix.popen
+import platform.posix.fgets
+import platform.posix.pclose
+import kotlinx.cinterop.refTo
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.ExperimentalForeignApi
+
+object AdbDeviceManager {
+    fun getConnectedDevices(): Pair<List<DeviceInfo>, String?> {
+        return try {
+            val output = executeAdbCommand("devices -l")
+            val devices = parseDevicesOutput(output)
+            Pair(devices, null)
+        } catch (e: Exception) {
+            Pair(emptyList(), "Failed to enumerate devices: ${e.message}")
+        }
+    }
+
+    private fun executeAdbCommand(args: String): String {
+        val result = StringBuilder()
+        val pipe = popen("adb $args 2>/dev/null", "r")
+        if (pipe == null) {
+            throw Exception("Failed to execute adb command")
+        }
+
+        return try {
+            val buffer = ByteArray(1024)
+            while (fgets(buffer.refTo(0), buffer.size, pipe) != null) {
+                result.append(buffer.toKString())
+            }
+            result.toString()
+        } finally {
+            pclose(pipe)
+        }
+    }
+
+    private fun parseDevicesOutput(output: String): List<DeviceInfo> {
+        val devices = mutableListOf<DeviceInfo>()
+        val lines = output.split("\n").drop(1) // Skip "List of attached devices" header
+
+        for (line in lines) {
+            if (line.isBlank()) continue
+
+            val trimmedLine = line.trim()
+            val parts = trimmedLine.split("\\s+".toRegex())
+            if (parts.size < 2) continue
+
+            val serial = parts[0]
+            val status = parts[1]
+
+            // Only include "device" status (online, debuggable)
+            if (status != "device") continue
+
+            // Extract model from "model:Pixel6Pro" part
+            val modelPart = parts.find { it.startsWith("model:") }
+            val model = if (modelPart != null) {
+                modelPart.substring(6).replace("_", " ")
+            } else {
+                "Unknown Device"
+            }
+
+            devices.add(DeviceInfo(serial, model, status))
+        }
+
+        return devices.sortedBy { it.serial }
+    }
+}

--- a/src/commonMain/kotlin/AppState.kt
+++ b/src/commonMain/kotlin/AppState.kt
@@ -7,7 +7,8 @@ enum class AppMode {
     DEBUG_CLASS_FILTER,
     DEBUG_INSPECT_CLASS,
     DEBUG_HOOK_WATCH,
-    DEBUG_EDIT_ATTRIBUTE
+    DEBUG_EDIT_ATTRIBUTE,
+    DEBUG_DEVICE_SELECTION
 }
 
 enum class GadgetInstallStatus {
@@ -16,6 +17,12 @@ enum class GadgetInstallStatus {
     SUCCESS,
     ERROR
 }
+
+data class DeviceInfo(
+    val serial: String,
+    val model: String,
+    val status: String
+)
 
 data class Command(val name: String, val description: String)
 
@@ -84,6 +91,10 @@ data class AppState(
     var selectedClassIndex: Int = -1,
     var isFetchingClasses: Boolean = false,
     var showSyntheticClasses: Boolean = false,
+    // Device Selection
+    var deviceInfoList: List<DeviceInfo> = emptyList(),
+    var isFetchingDevices: Boolean = false,
+    var selectedDeviceIndex: Int = 0,
     var rpcError: String? = null,
     
     var instanceCounts: MutableMap<String, Int> = mutableMapOf(),

--- a/src/commonMain/kotlin/CommandExecutor.kt
+++ b/src/commonMain/kotlin/CommandExecutor.kt
@@ -229,15 +229,13 @@ object CommandExecutor {
         scope.launch {
             val (devices, error) = AdbDeviceManager.getConnectedDevices()
 
-            if (error != null) {
-                state.rpcError = error
-                state.isFetchingDevices = false
-                return@launch
-            }
-
             when {
+                error != null -> {
+                    state.sharedRpcError.value = error
+                    state.isFetchingDevices = false
+                }
                 devices.isEmpty() -> {
-                    state.rpcError = "No online devices found. Check USB connection and developer mode"
+                    state.sharedRpcError.value = "No online devices found. Check USB connection and developer mode"
                     state.isFetchingDevices = false
                 }
                 devices.size == 1 -> {
@@ -247,13 +245,13 @@ object CommandExecutor {
                     proceedWithDebugSetup(state, scope)
                 }
                 else -> {
-                    // Show device selection UI
+                    // Show device selection UI - use shared observable pattern
                     state.deviceInfoList = devices
-                    state.displayedClasses = devices.map { "${it.serial} - ${it.model} - ${it.status}" }
-                    state.allFetchedClasses = emptyList()  // Clear to prevent displayedClasses corruption
+                    state.allFetchedClasses = emptyList()
                     state.selectedDeviceIndex = 0
                     state.isFetchingDevices = false
                     state.pushMode(AppMode.DEBUG_DEVICE_SELECTION)
+                    // Don't render here - Main.kt Timeout handler will render
                 }
             }
         }

--- a/src/commonMain/kotlin/CommandExecutor.kt
+++ b/src/commonMain/kotlin/CommandExecutor.kt
@@ -215,7 +215,51 @@ object CommandExecutor {
         if (state.gadgetInstallStatus == GadgetInstallStatus.WAITING_BRIDGE_SETUP) {
             return
         }
-        
+
+        // If serial already set (from device selection), proceed directly
+        if (state.adbSerial != null && state.adbSerial!!.isNotEmpty()) {
+            proceedWithDebugSetup(state, scope)
+            return
+        }
+
+        // Enumerate devices
+        state.isFetchingDevices = true
+        state.rpcError = null
+
+        scope.launch {
+            val (devices, error) = AdbDeviceManager.getConnectedDevices()
+
+            if (error != null) {
+                state.rpcError = error
+                state.isFetchingDevices = false
+                return@launch
+            }
+
+            when {
+                devices.isEmpty() -> {
+                    state.rpcError = "No online devices found. Check USB connection and developer mode"
+                    state.isFetchingDevices = false
+                }
+                devices.size == 1 -> {
+                    // Auto-select single device
+                    state.adbSerial = devices[0].serial
+                    state.isFetchingDevices = false
+                    proceedWithDebugSetup(state, scope)
+                }
+                else -> {
+                    // Show device selection UI
+                    state.deviceInfoList = devices
+                    state.displayedClasses = devices.map { "${it.serial} - ${it.model} - ${it.status}" }
+                    state.allFetchedClasses = emptyList()  // Clear to prevent displayedClasses corruption
+                    state.selectedDeviceIndex = 0
+                    state.isFetchingDevices = false
+                    state.pushMode(AppMode.DEBUG_DEVICE_SELECTION)
+                }
+            }
+        }
+    }
+
+    fun proceedWithDebugSetup(state: AppState, scope: CoroutineScope) {
         state.gadgetInstallStatus = GadgetInstallStatus.WAITING_BRIDGE_SETUP
         state.gadgetErrorMessage = null
         state.gadgetSpinnerFrame = 0
@@ -226,7 +270,13 @@ object CommandExecutor {
 
             // Smart check: if bridge is already responding, don't restart it
             if (!RpcClient.ping()) {
-                restartBridge(state, scope)
+                // Start bridge in background
+                val logFile = "${CacheManager.cacheDir()}/bridge.log"
+                val pidFile = "${CacheManager.cacheDir()}/bridge.pid"
+                val serialArg = if (state.adbSerial != null) " --serial ${state.adbSerial}" else ""
+                val bridgeCmd = getBridgeCommand(serialArg)
+                system("$bridgeCmd > \"$logFile\" 2>&1 & echo \$! > \"$pidFile\"")
+                delay(1000) // Give bridge time to start before first ping
             }
 
             var bridgeReady = false
@@ -250,14 +300,14 @@ object CommandExecutor {
             var isFinished = false
             while (!isFinished) {
                 val (progress, error) = RpcClient.injectGadgetFromScratch()
-                
+
                 if (error != null) {
                     state.sharedGadgetResult.value = Pair(GadgetInstallStatus.ERROR, error)
                     isFinished = true
                 } else if (progress != null) {
                     state.sharedGadgetSteps.value = progress.steps
                     state.sharedBridgeLogs.value = progress.logs
-                    
+
                     when (progress.status) {
                         "completed" -> {
                             state.sharedGadgetResult.value = Pair(GadgetInstallStatus.SUCCESS, null)

--- a/src/unixMain/kotlin/Main.kt
+++ b/src/unixMain/kotlin/Main.kt
@@ -497,6 +497,12 @@ fun main(args: Array<String>) {
                             (state.selectedClassIndex + 1).coerceAtMost(state.displayedClasses.size - 1)
                         Renderer.render(state)
                     }
+                } else if (state.mode == AppMode.DEBUG_DEVICE_SELECTION) {
+                    if (state.deviceInfoList.isNotEmpty()) {
+                        state.selectedDeviceIndex =
+                            (state.selectedDeviceIndex + 1).coerceAtMost(state.deviceInfoList.size - 1)
+                        Renderer.render(state)
+                    }
                 } else if (state.mode == AppMode.DEBUG_INSPECT_CLASS) {
                     val rows = state.buildInspectRows()
                     if (rows.isNotEmpty()) {
@@ -535,6 +541,12 @@ fun main(args: Array<String>) {
                     if (state.displayedClasses.isNotEmpty()) {
                         state.selectedClassIndex =
                             (state.selectedClassIndex - 1).coerceAtLeast(0)
+                        Renderer.render(state)
+                    }
+                } else if (state.mode == AppMode.DEBUG_DEVICE_SELECTION) {
+                    if (state.deviceInfoList.isNotEmpty()) {
+                        state.selectedDeviceIndex =
+                            (state.selectedDeviceIndex - 1).coerceAtLeast(0)
                         Renderer.render(state)
                     }
                 } else if (state.mode == AppMode.DEBUG_INSPECT_CLASS) {
@@ -606,6 +618,14 @@ fun main(args: Array<String>) {
                                 state.sharedRpcError.value = err
                             }
                         }
+                    }
+                } else if (state.mode == AppMode.DEBUG_DEVICE_SELECTION) {
+                    if (state.deviceInfoList.isNotEmpty() && state.selectedDeviceIndex in state.deviceInfoList.indices) {
+                        val selectedDevice = state.deviceInfoList[state.selectedDeviceIndex]
+                        state.adbSerial = selectedDevice.serial
+                        state.popMode()
+                        CommandExecutor.proceedWithDebugSetup(state, scope)
+                        Renderer.render(state)
                     }
                 } else if (state.mode == AppMode.DEBUG_ENTRYPOINT) {
                     CommandExecutor.handleDebugEntrypoint(state, scope)

--- a/src/unixMain/kotlin/Main.kt
+++ b/src/unixMain/kotlin/Main.kt
@@ -921,7 +921,7 @@ fun main(args: Array<String>) {
                     }
                 }
 
-                if ((state.mode == AppMode.DEBUG_CLASS_FILTER && state.isFetchingClasses) || state.isFetchingInstances || state.isFetchingInstancesList) {
+                if ((state.mode == AppMode.DEBUG_CLASS_FILTER && state.isFetchingClasses) || state.isFetchingInstances || state.isFetchingInstancesList || state.isFetchingDevices) {
                     state.gadgetSpinnerFrame++
                     needsRender = true
                 }
@@ -991,6 +991,18 @@ fun main(args: Array<String>) {
                             state.displayedClasses = CommandExecutor.sortClasses(state.displayedClasses, state.appPackageName, state.lastSearchedParam, state.showSyntheticClasses)
                             needsRender = true
                         }
+                    }
+                }
+
+                // Handle device enumeration (happens from DEFAULT or DEBUG_DEVICE_SELECTION mode)
+                if (state.isFetchingDevices) {
+                    // Handle device enumeration errors
+                    val err = state.sharedRpcError.value
+                    if (err != null) {
+                        state.rpcError = err
+                        state.sharedRpcError.value = null
+                        state.isFetchingDevices = false
+                        needsRender = true
                     }
                 }
 

--- a/src/unixMain/kotlin/Renderer.kt
+++ b/src/unixMain/kotlin/Renderer.kt
@@ -172,6 +172,10 @@ object Renderer {
             renderInputBox(buf, state, termWidth - 2)
             renderClassList(buf, state, termWidth, termHeight)
             hasInputBox = true
+        } else if (state.mode == AppMode.DEBUG_DEVICE_SELECTION) {
+            renderHeader(buf, state, termWidth)
+            renderDeviceSelectionList(buf, state, termWidth, termHeight)
+            hasInputBox = false
         } else if (state.mode == AppMode.DEBUG_INSPECT_CLASS || state.mode == AppMode.DEBUG_EDIT_ATTRIBUTE) {
             renderHeader(buf, state, termWidth)
             renderBreadcrumb(buf, state, termWidth)
@@ -265,6 +269,12 @@ object Renderer {
             AppMode.DEBUG_EDIT_ATTRIBUTE -> listOf(
                 FooterKey("Enter", "Save"),
                 FooterKey("Esc", "Cancel"),
+                FooterKey("Ctrl+C", "Quit")
+            )
+            AppMode.DEBUG_DEVICE_SELECTION -> listOf(
+                FooterKey("↑↓", "Navigate"),
+                FooterKey("Enter", "Select"),
+                FooterKey("Esc", "Back"),
                 FooterKey("Ctrl+C", "Quit")
             )
         }
@@ -909,6 +919,42 @@ object Renderer {
         }
 
         ListRenderer.renderScrollIndicator(buf, startIdx, endIdx, rows.size, termWidth)
+    }
+
+    private fun renderDeviceSelectionList(buf: StringBuilder, state: AppState, termWidth: Int, termHeight: Int) {
+        if (state.rpcError != null) {
+            buf.append(Ansi.RED).append("  Error: ${state.rpcError}").append(RESET).append("\n")
+            return
+        }
+
+        if (state.isFetchingDevices) {
+            buf.append("  ").append(DIM_GRAY).append("Fetching devices...").append(RESET).append("\n")
+            return
+        }
+
+        if (state.deviceInfoList.isEmpty()) {
+            buf.append(DIM_GRAY).append("  No devices found.\n").append(RESET)
+            return
+        }
+
+        val actualFixedLines = 2 + 3 // Header(2) + Footer(3)
+        val maxItems = maxOf(3, termHeight - actualFixedLines - 2)
+
+        val (startIdx, endIdx) = ListRenderer.computeViewport(
+            state.deviceInfoList.size, state.selectedDeviceIndex, maxItems
+        )
+
+        buf.append(DIM_GRAY).append("  Select a device to debug:").append(RESET).append("\n\n")
+
+        for (i in startIdx until endIdx) {
+            val device = state.deviceInfoList[i]
+            val displayStr = "${device.serial} - ${device.model} - ${device.status}"
+            val isSelected = i == state.selectedDeviceIndex
+            val prefix = ListRenderer.selectionPrefix(isSelected, "  ")
+
+            val displayColor = if (isSelected) WHITE else LIGHT_GRAY
+            buf.append(prefix).append(displayColor).append(displayStr).append(RESET).append("\n")
+        }
     }
 
     private fun renderHookWatchMode(buf: StringBuilder, state: AppState, termWidth: Int, termHeight: Int) {


### PR DESCRIPTION
## Summary

Add an interactive device selection UI that appears when user types "debug" and multiple Android devices are connected.

- Enumerate connected devices via `adb devices -l`
- Auto-select if only 1 device available
- Show interactive selection list with arrow key navigation for 2+ devices
- Pass selected device serial to bridge via `--serial` flag

## Implementation

- **AppMode**: Add `DEBUG_DEVICE_SELECTION` for device chooser UI
- **AdbDeviceManager**: New utility to enumerate devices and parse adb output
- **CommandExecutor**: Integrate device enumeration into `handleDebug()` with branching logic
- **Main.kt**: Add key event handlers for device list navigation and selection
- **Renderer.kt**: Add device list renderer with selection highlighting

## Test Plan

- [ ] No devices: Error message shown, return to menu
- [ ] Single device: Auto-select, proceed to gadget injection  
- [ ] Multiple devices: Show interactive list, navigate with ↑↓, select with Enter
- [ ] Esc key: Cancel selection, return to DEFAULT mode
- [ ] No regression: Existing debug flow still works with --serial CLI arg

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)