### PR TITLE
feat: replace JSON-RPC HTTP envelope with REST endpoints under /v0/api

### DIFF
--- a/.context/2026-09-09-rest-http-endpoints-design.md
+++ b/.context/2026-09-09-rest-http-endpoints-design.md
@@ -1,0 +1,252 @@
+# Design: Replace the JSON-RPC envelope with REST-style endpoints under /v0/api
+
+## Goal
+
+Remove the JSON-RPC 2.0 envelope (`jsonrpc`, `id`) from the HTTP transport. Today every
+call is a single `POST /rpc` with:
+
+```json
+{ "jsonrpc": "2.0", "id": 1, "method": "injectGadgetFromScratch", "params": { "with_logs": true, "limit": 100 } }
+```
+
+and returns:
+
+```json
+{ "jsonrpc": "2.0", "result": { "status": "completed", "steps": [] }, "id": 1 }
+```
+
+The target is one endpoint per method under `/v0/api/<snake_case>`, with the params object
+as the body and the plain result as the response:
+
+```
+POST /v0/api/inject_gadget_from_scratch
+{ "with_logs": true, "limit": 100 }
+
+→ 200
+{ "status": "completed", "steps": [] }
+```
+
+This drops one level of nesting on both input and output and makes the API trivial to
+call from curl or any HTTP client.
+
+## Scope
+
+- HTTP transport only (`Server.kt`, `RpcHandler.kt`, `RpcBase.kt`, tests, docs).
+- **MCP transport is intentionally untouched**: `barbatos mcp` keeps its camelCase tool
+  names and its JSON-RPC 2.0 wire protocol (MCP is JSON-RPC by spec). MCP and HTTP both
+  dispatch into the same `RpcHandler.processMethod`, which stays.
+- Frida-internal JSON-RPC (`FridaMessage.kt` / `FridaPayload.RpcRequest`) is a separate
+  channel inside the agent and is **not** part of this change.
+
+## Endpoint mapping
+
+camelCase method name → `POST /v0/api/<snake_case>`. Source of truth is
+`RpcHandler.tools` (13 wired methods), resolved via a `camelToSnake` helper.
+
+| Method (HTTP path) | Params schema | Result schema |
+|---|---|---|
+| `POST /v0/api/count_instances` | `CountInstancesParams` | `CountInstancesResult` |
+| `POST /v0/api/inspect_class` | `InspectClassParams` | `InspectClassResult` |
+| `POST /v0/api/list_instances` | `ListInstancesParams` | `ListInstancesResult` |
+| `POST /v0/api/get_instance_addresses` | `GetInstanceAddressesParams` | `GetInstanceAddressesResult` |
+| `POST /v0/api/inspect_instance` | `InspectInstanceParams` | `InspectInstanceResult` |
+| `POST /v0/api/set_field_value` | `SetFieldValueParams` | `StatusResult` |
+| `POST /v0/api/hook_method` | `HookParams` | `StatusResult` |
+| `POST /v0/api/get_hook_events` | (none) | `HookEventsResult` |
+| `POST /v0/api/set_method_implementation` | `SetMethodImplementationParams` | `StatusResult` |
+| `POST /v0/api/run_once` | `RunOnceParams` | `StatusResult` |
+| `POST /v0/api/inject_gadget_from_scratch` | `InjectGadgetParams` | `InjectGadgetResult` |
+| `POST /v0/api/health_check` | (none) | `HealthCheckResult` |
+| `POST /v0/api/list_classes_stream` | `ListClassesParams` | NDJSON stream of `ListClassesPartialResult` |
+
+Unimplemented/doc-only methods (`debugPing`, `testRpc`, `prepareEnvironment`,
+`injectJdwp`) exist in `web/openapi.yaml` but are **not** wired in
+`RpcHandler.processMethod` today — they would 404. See Decision D6.
+
+## Design decisions
+
+### D1 — Request body
+
+`POST /v0/api/<method>` carries the params object as the raw JSON body
+(`Content-Type: application/json`). For parameterless methods the body may be omitted
+or empty. `RpcHandler` decodes the body as a nullable `JsonElement` and passes it straight
+to `processMethod`; a missing body for a method that needs params fails with
+`Missing params` (same behavior as today).
+
+### D2 — Success response
+
+Plain serialized result; no envelope. The response body is exactly what
+`processMethod` currently places inside `result`.
+
+### D3 — Error response
+
+Alongside the envelope we drop the "#always 200" contract. Errors now use a body without
+`jsonrpc`/`id` and the natural HTTP status:
+
+```json
+{ "error": { "code": -32603, "message": "..." } }
+```
+
+| Case | HTTP status | code |
+|---|---|---|
+| Malformed JSON body / empty body where params required | `400` | `-32700` |
+| Unknown endpoint (not under `/v0/api`) | `404` | `-32601` |
+| Bridge / handler threw | `500` | `-32603` |
+
+The numeric codes are kept for continuity with MCP tool errors and any client that logs
+them; only the envelope is removed. `CLAUDE.md`'s "always HTTP 200 for application-level
+errors" rule is updated to reflect this (HTTP transport), while MCP keeps the JSON-RPC
+codes it already uses.
+
+### D4 — /rpc backwards compatibility
+
+**Removal is recommended** — the project is at `2.0.0-alpha`, so breaking the HTTP
+surface now is cheap and avoids carrying two parsers. If kept, add an alias route that
+maps a `method` field to the same handler; still recommend shipping a deprecation and
+removing in the next minor.
+
+### D5 — Streaming (`list_classes_stream`)
+
+Stays NDJSON (`application/x-ndjson`). Each line becomes the plain chunk object:
+
+```json
+{ "list": ["com.example.MainActivity"] }
+```
+
+instead of the `RpcResponse` envelope. A mid-stream failure emits one error line
+`{"error":{"code":-32603,"message":"..."}}` and ends the stream.
+
+MCP's `streamToolResult` accumulates these plain chunk lines instead of envelopes; its
+error detection changes from "decodes as `RpcErrorResponse`" to "line contains an
+`error` member".
+
+### D6 — Doc-only methods
+
+`debugPing`, `testRpc`, `prepareEnvironment`, `injectJdwp` are documented in
+`web/openapi.yaml` but have no dispatch in `RpcHandler.processMethod` and are absent
+from `RpcHandler.tools`. They also have Gradle `registerRpcTask` entries. **Recommendation:**
+the new spec only advertises endpoints that actually route. Either (a) implement the four
+methods in `processMethod` + add descriptors, or (b) drop them from the spec and from the
+Gradle task list. Default to (a) for `prepareEnvironment`/`injectJdwp` (they are
+referenced as low-level recovery steps in the session lifecycle docs) and (b) for
+`debugPing`/`testRpc` unless they are wired to something real.
+
+## Code changes
+
+### `src/commonMain/kotlin/model/rpc/RpcBase.kt`
+- Delete `RpcRequest`, `RpcResponse`, `RpcErrorResponse` (only the HTTP path uses them).
+- Add `ApiError(code: Int, message: String)` and `ApiErrorResponse(error: ApiError)`.
+- `RpcError` can be reused or folded into `ApiError`.
+
+### `src/commonMain/kotlin/rpc/RpcHandler.kt`
+- Add `camelToSnake(name: String)` and expose the route table, e.g.
+  `val routeByPath: Map<String, ActionDescriptor>` built from `tools` (both directions:
+  path → tool, tool → path). Keep `tools` as the single registry.
+- `isStreamMethod(method: String): Boolean` — drop the JSON-parsing implementation.
+- `handleStream(method: String, paramsJson: String?, emit: suspend (String) -> Unit)` —
+  emit plain `ListClassesPartialResult` lines; error line has no envelope.
+- `handle(method: String, body: String?): HandlerResult` — decodes the body
+  (null on empty), routes to `processMethod`, returns plain result or `ApiErrorResponse`.
+  Parse errors return `code = -32700`.
+- Keep `processMethod(method, params)` unchanged (MCP still calls it).
+- `streamToolResult(method, params)` for MCP: serialize params directly (no envelope)
+  and detect errors from plain error lines.
+
+### `src/commonMain/kotlin/Server.kt`
+- In `routing {}`, iterate `RpcHandler.tools`, registering
+  `post("/v0/api/${snake_case(name)}")` for each. The stream tool uses
+  `respondBytesWriter` with `application/x-ndjson`; everything else is a single JSON object.
+- Add a fallback `post("/v0/api/{...}")` → `404` for unknown endpoints.
+- Remove the `post("/rpc")` block (per D4).
+
+### `src/commonMain/kotlin/DocsRoutes.kt`
+- Update the doc comment that references `/rpc`.
+
+### `src/unixMain/kotlin/Main.kt`
+- Update the `rpc` help block: `POST /v0/api/<snake_case>` + `GET /ping`, `GET /docs`,
+  `GET /openapi.yaml`.
+
+### `web/openapi.yaml`
+The single source of truth — rewrite for the new surface:
+- `paths` gains one `post` per endpoint under `/v0/api/...` with `requestBody` = the
+  corresponding `*Params` schema and a `200` response = the result schema; add schemes
+  for `400`/`404`/`500` referencing an `ApiError` schema.
+- Remove `RpcRequest`/`RpcResponse`/`RpcErrorResponse`/`JsonRpcError`; add `ApiError`.
+- Replace the "JSON-RPC method contract" section with a per-endpoint description;
+  rewrite the transports table (`barbatos rpc` row) and the error-handling section.
+- Keep the `*Params`/result schemas unchanged — they are still valid request/response
+  bodies, just without the wrapper.
+- Bump `version` (e.g. `2.0.0-alpha03`) and note the MCP transport keeps tool names.
+
+### `build.gradle.kts`
+- `registerRpcTask`: post to the new URL and send the params object only (no
+  `jsonrpc`/`id`). Keep the `barbatos-rpc` gradle tasks or drop/update per D6.
+
+### `CLAUDE.md`
+- Update the RPC protocol rules: HTTP transport now returns real status codes and no
+  envelope; JSON-RPC error codes still apply on the MCP transport.
+
+### `README.md`
+- Update the curl example and the "JSON-RPC 2.0 API" feature bullet / architecture
+  diagram label to reflect the REST surface (MCP bullet stays).
+
+## Test changes
+
+### `src/commonTest/kotlin/rpc/RpcHandlerTest.kt`
+- Convert every fixture from
+  `{"jsonrpc":"2.0","method":"X","id":n,"params":{...}}` to
+  `handle("x_snake_case", body)`.
+- Rewrite assertions: decode `ApiErrorResponse` for errors, plain object for success.
+- Add tests:
+  - `camelToSnake` covers all 13 tools (injectGadgetFromScratch →
+    inject_gadget_from_scratch, getInstanceAddresses → get_instance_addresses, …).
+  - `handle` parse error → `-32700`; unknown path → `-32601`; bridge throw → `-32603`.
+  - `handleStream` emits plain chunks (no envelope) and an error line on failure.
+- Keep MCP-facing tests intact where they assert `processMethod` behavior.
+
+### `src/commonTest/kotlin/mcp/McpServerTest.kt`
+- `toolsCall_listClassesStream_returnsAccumulatedChunks` asserts the text contains
+  `"result"` (the old envelope) — update to assert the plain `"list"` chunk instead.
+- Add an HTTP routing smoke test (optional but cheap, `ktor-server-test-host` is already
+  a dependency): start `module(FakeFridaBridge())`, assert
+  `GET /ping`, `POST /v0/api/health_check`, `POST /v0/api/count_instances`,
+  `POST /v0/api/inject_gadget_from_scratch`, unknown path → 404.
+
+## Example calls after the change
+
+```bash
+curl -s http://127.0.0.1:8080/v0/api/health_check
+# {"overall":"ok","checks":{...},"recommendation":null}
+
+curl -s -X POST http://127.0.0.1:8080/v0/api/count_instances \
+  -H 'Content-Type: application/json' \
+  -d '{"className":"com.example.MainActivity"}'
+# {"count":5}
+
+curl -s -X POST http://127.0.0.1:8080/v0/api/inject_gadget_from_scratch \
+  -H 'Content-Type: application/json' \
+  -d '{"with_logs":true,"limit":100}'
+# {"status":"completed","steps":[...],"logs":null}
+
+curl -s -X POST http://127.0.0.1:8080/v0/api/list_classes_stream \
+  -H 'Content-Type: application/json' \
+  -d '{"search_param":"Main"}'
+# application/x-ndjson: {"list":["com.example.MainActivity"]}
+```
+
+## Validation
+
+1. `./scripts/download_frida_devkit.sh arm64`
+2. `./gradlew macosArm64Test` (Linux: `linuxX64Test`)
+3. `./gradlew clean check`
+4. Manual smoke: run the binary, hit the endpoints above, confirm `/docs` renders the
+   updated spec.
+
+## Risks / notes
+
+- **Breaking change to the whole HTTP surface** — mitigated by the `2.0.0-alpha` version.
+- `.context/` plans, `.claude/settings.local.json` curl examples and old `README`/`GEMINI`
+  references mention `/rpc`; historical docs are left as-is, live docs are updated.
+- MCP tests must stay green: tool names, schemas and `processMethod` are unchanged.
+- The 13 endpoint paths are derived from one registry (`RpcHandler.tools`), so a new
+  method automatically gets both an MCP tool and an HTTP route with no extra wiring.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 
 ## Technical Architecture
 - **Multiplatform**: Logic in `src/commonMain`, platform-specific entry and Frida bindings in `src/unixMain`.
-- **API**: Ktor-based JSON-RPC 2.0 server on port 8080.
+- **API**: Ktor-based HTTP server on port 8080. REST endpoints under `/v0/api/*` in RPC mode; JSON-RPC 2.0 over Streamable HTTP in MCP mode.
 - **Frida Integration**: Kotlin Native CInterop mapped to `libfrida-core.a`.
 - **Mocking**: `MockFridaBridge` used for all unit tests to simulate Frida behavior without devices.
 
@@ -18,11 +18,13 @@
 - **Language**: All code and documentation must be in **English**.
 - **TDD**: New endpoints must have corresponding test cases in `RpcHandlerTest.kt`.
 - **RPC Protocol**:
-    - Always return **HTTP 200** for application-level errors (method not found, etc.).
-    - Use standard JSON-RPC 2.0 error codes:
+    - HTTP transport (`barbatos rpc`): one `POST /v0/api/<snake_case>` per method. The body is the params object and the response is the plain result — no `jsonrpc`/`id` envelope.
+    - Errors use real HTTP statuses: `400` malformed body, `404` unknown endpoint, `500` internal error, with a body of `{"error":{"code","message"}}`.
+    - Keep standard JSON-RPC error codes in the `error` body for traceability:
         - `-32700`: Parse error
         - `-32601`: Method not found
         - `-32603`: Internal error
+    - The MCP transport keeps JSON-RPC 2.0 semantics and forwards application-level errors as non-error MCP results.
 - **Style**:
     - Use `HandlerResult` for robust HTTP response handling in the server.
     - Prefer interface-driven design (`FridaBridge`).
@@ -30,7 +32,7 @@
     - No emojis in commit messages or code.
 
 ## File Structure
-- `src/commonMain/kotlin/rpc/`: JSON-RPC models and handler logic.
+- `src/commonMain/kotlin/rpc/`: HTTP and MCP handler logic (models + dispatch).
 - `src/commonMain/kotlin/bridge/`: Bridge interfaces and mocks.
 - `src/unixMain/kotlin/bridge/`: Real Frida Core implementation.
 - `src/commonMain/resources/`: Frida JS agents.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 ## Key Features
 
 *   **Unified Native Binary:** Single executable for macOS. No dependencies, no setup.
-*   **JSON-RPC 2.0 API:** Standardized interface over HTTP/Post for consistent integration.
+*   **REST API:** One `POST /v0/api/<snake_case>` endpoint per operation — the params object as the body, the plain result back, no JSON-RPC envelope.
 *   **Class Discovery:** Real-time enumeration of loaded Java/Kotlin classes.
 *   **Deep Inspection:** Recursive traversal of object hierarchies (Fields, Maps, Collections).
 *   **Method Hooking:** Intercept execution flow and modify behavior in real-time.
@@ -51,7 +51,7 @@ Barbatos uses a streamlined pipeline for zero-latency runtime interaction:
 
 ```mermaid
 graph TD
-    A[MCP Client / Any http request] -->|JSON-RPC| B[KMP Native Bridge]
+    A[MCP Client / Any http request] -->|REST / JSON-RPC| B[KMP Native Bridge]
     B -->|CInterop| D[Frida Core]
     D -->|Injection| E[Frida JS Agent]
     E -->|ART/ObjC| F[Target App]
@@ -78,13 +78,13 @@ make run
 ```
 
 ### API Usage
-The bridge exposes a JSON-RPC 2.0 endpoint at `http://127.0.0.1:8080/rpc`.
+The bridge exposes one REST endpoint per operation at `http://127.0.0.1:8080/v0/api/<snake_case>`.
 
 ```bash
-# Example: List loaded classes
-curl -X POST http://127.0.0.1:8080/rpc \
+# Example: Search loaded classes (NDJSON stream)
+curl -X POST http://127.0.0.1:8080/v0/api/list_classes_stream \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0", "method": "listClasses", "params": {"search_param": "MainActivity"}, "id": 1}'
+  -d '{"search_param": "MainActivity"}'
 ```
 [click here to see full swagger doc >](https://barbatos.victorlpgazolli.dev/openapi)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -287,10 +287,13 @@ kotlin {
     }
 }
 
+fun snakeCase(methodName: String): String =
+    methodName.replace(Regex("([a-z0-9])([A-Z])"), "$1_$2").lowercase()
+
 fun registerRpcTask(taskName: String, methodName: String, params: Map<String, Any?> = emptyMap()) {
     tasks.register<Exec>(taskName) {
         group = "barbatos-rpc"
-        description = "Execute JSON-RPC method $methodName via curl"
+        description = "Execute method $methodName via curl"
 
         executable = "curl"
 
@@ -323,16 +326,15 @@ fun registerRpcTask(taskName: String, methodName: String, params: Map<String, An
 
             listOf(
                 "-s", "--connect-timeout", "5", "--max-time", "15",
-                "-X", "POST", "http://localhost:8080/rpc",
+                "-X", "POST", "http://localhost:8080/v0/api/${snakeCase(methodName)}",
                 "-H", "Content-Type: application/json",
-                "-d", """{"jsonrpc":"2.0","method":"$methodName","params":$paramsJson,"id":1}"""
+                "-d", paramsJson
             )
         })
     }
 }
 
 // Exploration Tools
-registerRpcTask("rpcListClasses", "listClasses", mapOf("search_param" to "", "app_package" to "", "offset" to 0, "limit" to 200))
 registerRpcTask("rpcListClassesStream", "listClassesStream", mapOf("search_param" to "", "app_package" to "", "offset" to 0, "limit" to 200))
 registerRpcTask("rpcCountInstances", "countInstances", mapOf("className" to ""))
 registerRpcTask("rpcInspectClass", "inspectClass", mapOf("className" to ""))
@@ -350,16 +352,8 @@ registerRpcTask("rpcHookMethod", "hookMethod", mapOf("className" to "", "methodS
 registerRpcTask("rpcGetHookEvents", "getHookEvents")
 
 // Environment Tools
-registerRpcTask("rpcPrepareEnvironment", "prepareEnvironment", mapOf("target" to "Gadget"))
 registerRpcTask("rpcInjectGadgetFromScratch", "injectGadgetFromScratch")
-registerRpcTask("rpcInjectJdwp", "injectJdwp", mapOf("target" to "127.0.0.1", "port" to 5005, "package_name" to ""))
 registerRpcTask("rpcHealthCheck", "healthCheck")
-
-// iOS Specific Tools
-registerRpcTask("rpcPatchAndInstallIosApp", "patchAndInstallIosApp", mapOf("appPath" to ""))
-registerRpcTask("rpcCheckIosJailbreakStatus", "checkIosJailbreakStatus", mapOf("serial" to ""))
-registerRpcTask("rpcInjectJailbrokenIos", "injectJailbrokenIos", mapOf("serial" to ""))
-registerRpcTask("rpcCheckIosDeployStatus", "checkIosDeployStatus")
 
 tasks.register<Exec>("runDebug") {
     group = "application"

--- a/src/commonMain/kotlin/DocsRoutes.kt
+++ b/src/commonMain/kotlin/DocsRoutes.kt
@@ -36,7 +36,8 @@ private val swaggerUiHtml = """
 """.trimIndent()
 
 /**
- * Swagger UI for the JSON-RPC bridge, served off the same port as `/rpc`.
+ * OpenAPI documentation for the REST API, served off the same port as the
+ * /v0/api endpoints.
  *
  * Installed by [module], so it only exists in HTTP mode — `barbatos mcp` never builds a
  * routing tree.

--- a/src/commonMain/kotlin/Server.kt
+++ b/src/commonMain/kotlin/Server.kt
@@ -24,6 +24,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.error
 import io.modelcontextprotocol.kotlin.sdk.types.success
 import rpc.RpcHandler
+import rpc.camelToSnake
 import model.bridge.FridaBridge
 import platform.posix.fprintf
 import platform.posix.stderr
@@ -101,27 +102,37 @@ fun Application.module(bridge: FridaBridge) {
         get("/ping") {
             call.respondText("""{"status": "pong"}""", ContentType.Application.Json)
         }
-        post("/rpc") {
-            val body = call.receiveText()
+        RpcHandler.tools.forEach { tool ->
+            val path = "/v0/api/${camelToSnake(tool.name)}"
+            post(path) {
+                val body = call.receiveText()
 
-            if (rpcHandler.isStreamMethod(body)) {
-                val ndjsonType = ContentType.parse("application/x-ndjson")
-                call.respondBytesWriter(contentType = ndjsonType) {
-                    try {
-                        rpcHandler.handleStream(body) { line ->
-                            try {
-                                writeFully((line + "\n").encodeToByteArray())
-                                flush()
-                            } catch (e: Exception) {
-                                println("[SERVER] Client disconnected ${e.message}")
+                if (tool.isStreamingOutput) {
+                    val ndjsonType = ContentType.parse("application/x-ndjson")
+                    call.respondBytesWriter(contentType = ndjsonType) {
+                        try {
+                            rpcHandler.handleStream(tool.name, body) { line ->
+                                try {
+                                    writeFully((line + "\n").encodeToByteArray())
+                                    flush()
+                                } catch (e: Exception) {
+                                    println("[SERVER] Client disconnected ${e.message}")
+                                }
                             }
-                        }
-                    } catch (e: Exception) {}
+                        } catch (e: Exception) {}
+                    }
+                } else {
+                    val result = rpcHandler.handle(tool.name, body)
+                    call.respondText(result.body, ContentType.Application.Json, HttpStatusCode.fromValue(result.statusCode))
                 }
-            } else {
-                val result = rpcHandler.handle(body)
-                call.respondText(result.body, ContentType.Application.Json, HttpStatusCode.fromValue(result.statusCode))
             }
+        }
+        post("/v0/api/{path}") {
+            call.respondText(
+                """{"error":{"code":-32601,"message":"Method not found"}}""",
+                ContentType.Application.Json,
+                HttpStatusCode.NotFound
+            )
         }
     }
 }

--- a/src/commonMain/kotlin/model/rpc/RpcBase.kt
+++ b/src/commonMain/kotlin/model/rpc/RpcBase.kt
@@ -1,21 +1,9 @@
 package model.rpc
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
 
 @Serializable
-data class RpcRequest(val jsonrpc: String = "2.0", val method: String, val params: JsonElement? = null, val id: JsonElement? = null)
+data class ApiError(val code: Int, val message: String)
 
 @Serializable
-data class RpcError(val code: Int, val message: String, val data: JsonElement? = null)
-
-@Serializable
-data class RpcErrorResponse(val jsonrpc: String = "2.0", val error: RpcError, val id: JsonElement?)
-
-@Serializable
-data class RpcResponse(
-    val jsonrpc: String = "2.0",
-    val result: JsonElement,
-    val id: JsonElement?
-)
-
+data class ApiErrorResponse(val error: ApiError)

--- a/src/commonMain/kotlin/rpc/RpcHandler.kt
+++ b/src/commonMain/kotlin/rpc/RpcHandler.kt
@@ -4,15 +4,29 @@ import model.bridge.FridaBridge
 import kotlinx.serialization.json.*
 import model.actions.ActionDescriptor
 import model.actions.params.*
-import model.rpc.RpcError
-import model.rpc.RpcErrorResponse
-import model.rpc.RpcRequest
-import model.rpc.RpcResponse
+import model.actions.result.ListClassesPartialResult
+import model.rpc.ApiError
+import model.rpc.ApiErrorResponse
 import utils.decodeToOrThrow
 
 data class HandlerResult(val body: String, val statusCode: Int)
 
 data class StreamToolResult(val content: String, val isError: Boolean)
+
+/**
+ * Converts a camelCase method name to the snake_case HTTP path segment, e.g.
+ * `injectGadgetFromScratch` -> `inject_gadget_from_scratch`.
+ */
+fun camelToSnake(name: String): String = buildString {
+    for (c in name) {
+        if (c.isUpperCase()) {
+            append('_')
+            append(c.lowercaseChar())
+        } else {
+            append(c)
+        }
+    }
+}
 
 class RpcHandler(private val bridge: FridaBridge) {
     val jsonParser = Json {
@@ -20,29 +34,23 @@ class RpcHandler(private val bridge: FridaBridge) {
         encodeDefaults = true
     }
 
-    fun isStreamMethod(requestJson: String): Boolean {
-        return try {
-            val req = jsonParser.decodeFromString<RpcRequest>(requestJson)
-            req.method == "listClassesStream"
-        } catch (e: Exception) {
-            false
-        }
-    }
+    fun isStreamMethod(method: String): Boolean = method == LIST_CLASSES_STREAM.name
 
-    suspend fun handleStream(requestJson: String, emit: suspend (String) -> Unit) {
-        val req = try {
-            jsonParser.decodeFromString<RpcRequest>(requestJson)
+    suspend fun handleStream(method: String, body: String?, emit: suspend (String) -> Unit) {
+        val params = try {
+            if (body.isNullOrBlank()) null else jsonParser.parseToJsonElement(body)
         } catch (e: Exception) {
-            val errorStr = jsonParser.encodeToString(
-                RpcErrorResponse.serializer(),
-                RpcErrorResponse(error = RpcError(-32700, "Parse error: ${e.message}"), id = null)
-            )
-            emit(errorStr)
+            emit(errorJson(-32700, "Parse error: ${e.message}"))
             return
         }
 
-        if (req.method == "listClassesStream") {
-            val p = req.params?.let { jsonParser.decodeFromJsonElement<ListClassesParams>(it) } ?: ListClassesParams()
+        if (params != null && params !is JsonObject) {
+            emit(errorJson(-32700, "Parse error: expected a JSON object"))
+            return
+        }
+
+        if (method == LIST_CLASSES_STREAM.name) {
+            val p = params?.let { jsonParser.decodeFromJsonElement<ListClassesParams>(it) } ?: ListClassesParams()
 
             try {
                 bridge.listClassesStream(
@@ -53,62 +61,43 @@ class RpcHandler(private val bridge: FridaBridge) {
                         limit = p.limit,
                     ),
                     onChunk = { chunk ->
-                        val res = RpcResponse(
-                            result = jsonParser.encodeToJsonElement(chunk),
-                            id = req.id
-                        )
-                        val jsonStr = jsonParser.encodeToString(RpcResponse.serializer(), res)
-
-                        emit(jsonStr)
+                        emit(jsonParser.encodeToString(ListClassesPartialResult.serializer(), chunk))
                     },
                     onComplete = {}
                 )
             } catch (e: Exception) {
-                val errorStr = jsonParser.encodeToString(
-                    RpcErrorResponse.serializer(),
-                    RpcErrorResponse(
-                        error = RpcError(-32603, e.message ?: "Internal stream error"),
-                        id = req.id
-                    )
-                )
-                emit(errorStr)
+                emit(errorJson(-32603, e.message ?: "Internal stream error"))
             }
         }
     }
 
-    fun handle(requestJson: String): HandlerResult {
-        val req = try {
-            jsonParser.decodeFromString<RpcRequest>(requestJson)
+    /**
+     * Handles a single HTTP call to [method]. The body is the raw params object (no
+     * JSON-RPC envelope); the response is the plain result or an [ApiErrorResponse].
+     */
+    fun handle(method: String, body: String? = null): HandlerResult {
+        val params = try {
+            if (body.isNullOrBlank()) null else jsonParser.parseToJsonElement(body)
         } catch (e: Exception) {
-            return HandlerResult(
-                jsonParser.encodeToString(
-                    RpcErrorResponse.serializer(),
-                    RpcErrorResponse(
-                        error = RpcError(-32700, "Parse error: ${e.message}"),
-                        id = null
-                    )
-                ),
-                200
-            )
+            return HandlerResult(errorJson(-32700, "Parse error: ${e.message}"), 400)
+        }
+
+        if (params != null && params !is JsonObject) {
+            return HandlerResult(errorJson(-32700, "Parse error: expected a JSON object"), 400)
+        }
+
+        if (params == null && tools.any { it.name == method && it.scheme.required.isNotEmpty() }) {
+            return HandlerResult(errorJson(-32700, "Missing params"), 400)
         }
 
         return try {
-            val result = processMethod(req.method, req.params)
-            HandlerResult(
-                jsonParser.encodeToString(RpcResponse.serializer(), RpcResponse(result = result, id = req.id)),
-                200
-            )
+            val result = processMethod(method, params)
+            HandlerResult(result.toString(), 200)
         } catch (e: Exception) {
-            val code = if (e.message?.contains("not found") == true) -32601 else -32603
+            val notFound = e.message?.contains("not found") == true
             HandlerResult(
-                jsonParser.encodeToString(
-                    RpcErrorResponse.serializer(),
-                    RpcErrorResponse(
-                        error = RpcError(code, e.message ?: "Internal error"),
-                        id = req.id
-                    )
-                ),
-                200
+                errorJson(if (notFound) -32601 else -32603, e.message ?: "Internal error"),
+                if (notFound) 404 else 500
             )
         }
     }
@@ -118,22 +107,21 @@ class RpcHandler(private val bridge: FridaBridge) {
      * accumulates every emitted line so it can be returned as a single MCP tool result.
      */
     suspend fun streamToolResult(method: String, params: JsonElement?): StreamToolResult {
-        val requestJson = jsonParser.encodeToString(
-            RpcRequest.serializer(),
-            RpcRequest(method = method, params = params)
-        )
+        val body = params?.toString()
         val lines = mutableListOf<String>()
-        handleStream(requestJson) { line -> lines.add(line) }
+        handleStream(method, body) { line -> lines.add(line) }
         val content = lines.joinToString("\n")
         return StreamToolResult(content = content, isError = lines.any { isErrorLine(it) })
     }
 
     private fun isErrorLine(line: String): Boolean = try {
-        jsonParser.decodeFromString<RpcErrorResponse>(line).error
-        true
+        "error" in jsonParser.parseToJsonElement(line).jsonObject
     } catch (e: Exception) {
         false
     }
+
+    private fun errorJson(code: Int, message: String): String =
+        jsonParser.encodeToString(ApiErrorResponse.serializer(), ApiErrorResponse(ApiError(code, message)))
 
     public fun processMethod(method: String, params: JsonElement?): JsonElement {
         return when (method) {
@@ -187,7 +175,11 @@ class RpcHandler(private val bridge: FridaBridge) {
                 jsonParser.encodeToJsonElement(res)
             }
             INJECT_GADGET_FROM_SCRATCH.name -> {
-                val decodedParams = decodeToOrThrow<InjectGadgetParams>(params)
+                val decodedParams = if (params == null) {
+                    InjectGadgetParams()
+                } else {
+                    decodeToOrThrow<InjectGadgetParams>(params)
+                }
                 val result = bridge.injectGadgetFromScratch(decodedParams)
                 jsonParser.encodeToJsonElement(result)
             }
@@ -320,5 +312,6 @@ class RpcHandler(private val bridge: FridaBridge) {
             HEALTH_CHECK,
         )
 
+        internal val routeByPath: Map<String, ActionDescriptor> = tools.associateBy { camelToSnake(it.name) }
     }
 }

--- a/src/commonTest/kotlin/mcp/McpServerTest.kt
+++ b/src/commonTest/kotlin/mcp/McpServerTest.kt
@@ -134,7 +134,8 @@ class McpServerTest {
             assertEquals(false, result.isError)
             val text = (result.content.first() as TextContent).text
             assertTrue(text.contains("com.example.MainActivity"), "Streamed chunks must include the matching class, got: $text")
-            assertTrue(text.contains("result"), "Each streamed chunk must be a JSON-RPC response envelope, got: $text")
+            assertTrue(text.contains("\"list\""), "Each streamed chunk must be a plain partial result, got: $text")
+            assertTrue(!text.contains("jsonrpc"), "Streamed chunks must not carry the JSON-RPC envelope, got: $text")
         } finally {
             connection.client.close()
         }

--- a/src/commonTest/kotlin/rpc/RpcHandlerTest.kt
+++ b/src/commonTest/kotlin/rpc/RpcHandlerTest.kt
@@ -7,43 +7,56 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.int
+import kotlinx.serialization.json.JsonObject
 import model.actions.result.CheckResponse
 import model.actions.result.CountInstancesResult
 import model.actions.result.HealthCheckResult
-import model.rpc.RpcErrorResponse
-import model.rpc.RpcResponse
+import model.rpc.ApiErrorResponse
 
 /**
  * Unit tests for RpcHandler.
  *
- * All tests call RpcHandler.handle() / handleStream() / isStreamMethod() directly.
+ * All tests call RpcHandler.handle() / handleStream() / processMethod() directly.
  * No Ktor, no HTTP layer involved.
  */
 class RpcHandlerTest {
 
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
 
+    // ─── camelToSnake / route table ───────────────────────────────────────────
+
+    @Test
+    fun camelToSnake_convertsCamelCaseMethods() {
+        assertEquals("inject_gadget_from_scratch", camelToSnake("injectGadgetFromScratch"))
+        assertEquals("get_instance_addresses", camelToSnake("getInstanceAddresses"))
+        assertEquals("set_method_implementation", camelToSnake("setMethodImplementation"))
+        assertEquals("list_classes_stream", camelToSnake("listClassesStream"))
+        assertEquals("health_check", camelToSnake("healthCheck"))
+        assertEquals("count_instances", camelToSnake("countInstances"))
+        assertEquals("run_once", camelToSnake("runOnce"))
+    }
+
+    @Test
+    fun routeByPath_coversAllTools() {
+        val handler = RpcHandler(FakeFridaBridge())
+        assertEquals(RpcHandler.tools.size, RpcHandler.routeByPath.size)
+        RpcHandler.tools.forEach { tool ->
+            assertTrue(RpcHandler.routeByPath.containsKey(camelToSnake(tool.name)), "Missing route for ${tool.name}")
+        }
+    }
+
     // ─── isStreamMethod ───────────────────────────────────────────────────────
 
     @Test
     fun isStreamMethod_returnsTrue_forListClassesStream() {
         val handler = RpcHandler(FakeFridaBridge())
-        assertTrue(handler.isStreamMethod("""{"jsonrpc":"2.0","method":"listClassesStream","id":1}"""))
+        assertTrue(handler.isStreamMethod("listClassesStream"))
     }
 
     @Test
     fun isStreamMethod_returnsFalse_forNonStreamMethod() {
         val handler = RpcHandler(FakeFridaBridge())
-        assertFalse(handler.isStreamMethod("""{"jsonrpc":"2.0","method":"healthCheck","id":1}"""))
-    }
-
-    @Test
-    fun isStreamMethod_returnsFalse_forInvalidJson() {
-        val handler = RpcHandler(FakeFridaBridge())
-        assertFalse(handler.isStreamMethod("not-json"))
+        assertFalse(handler.isStreamMethod("healthCheck"))
     }
 
     // ─── handle — parse errors ────────────────────────────────────────────────
@@ -51,18 +64,19 @@ class RpcHandlerTest {
     @Test
     fun handle_returnsParseError_onInvalidJson() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("not-json")
-        val err = json.decodeFromString<RpcErrorResponse>(result.body)
+        val result = handler.handle("healthCheck", "not-json")
+        val err = json.decodeFromString<ApiErrorResponse>(result.body)
         assertEquals(-32700, err.error.code)
-        assertTrue(err.id == null || err.id is JsonNull || err.id.toString() == "null", "ID should be null")
+        assertEquals(400, result.statusCode)
     }
 
     @Test
-    fun handle_returnsParseError_onEmptyBody() {
+    fun handle_returnsBadRequest_onEmptyBody_forMethodRequiringParams() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("")
-        val err = json.decodeFromString<RpcErrorResponse>(result.body)
+        val result = handler.handle("countInstances")
+        val err = json.decodeFromString<ApiErrorResponse>(result.body)
         assertEquals(-32700, err.error.code)
+        assertEquals(400, result.statusCode)
     }
 
     // ─── handle — method not found ────────────────────────────────────────────
@@ -70,18 +84,10 @@ class RpcHandlerTest {
     @Test
     fun handle_returnsMethodNotFound_onUnknownMethod() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"unknownMethod","id":1}""")
-        val err = json.decodeFromString<RpcErrorResponse>(result.body)
+        val result = handler.handle("unknownMethod")
+        val err = json.decodeFromString<ApiErrorResponse>(result.body)
         assertEquals(-32601, err.error.code)
-        assertEquals(1, err.id?.jsonPrimitive?.int)
-    }
-
-    @Test
-    fun handle_preservesId_onMethodNotFound() {
-        val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"nope","id":99}""")
-        val err = json.decodeFromString<RpcErrorResponse>(result.body)
-        assertEquals(99, err.id?.jsonPrimitive?.int)
+        assertEquals(404, result.statusCode)
     }
 
     // ─── handle — bridge throws → internal error ──────────────────────────────
@@ -90,54 +96,23 @@ class RpcHandlerTest {
     fun handle_returnsInternalError_whenBridgeThrows() {
         val bridge = FakeFridaBridge(countInstancesFn = { throw RuntimeException("bridge failure") })
         val handler = RpcHandler(bridge)
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"countInstances","params":{"className":"com.example.MainActivity"},"id":5}""")
-        val err = json.decodeFromString<RpcErrorResponse>(result.body)
+        val result = handler.handle("countInstances", """{"className":"com.example.MainActivity"}""")
+        val err = json.decodeFromString<ApiErrorResponse>(result.body)
         assertEquals(-32603, err.error.code)
+        assertEquals(500, result.statusCode)
         assertTrue(err.error.message.contains("bridge failure"))
     }
 
-    // ─── handle — missing params → internal error ─────────────────────────────
+    // ─── handle — success responses have no envelope ──────────────────────────
 
     @Test
-    fun handle_returnsInternalError_whenParamsMissing_countInstances() {
+    fun handle_successResponse_isPlainResult() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"countInstances","id":1}""")
-        val err = json.decodeFromString<RpcErrorResponse>(result.body)
-        assertEquals(-32603, err.error.code)
-    }
-
-    @Test
-    fun handle_returnsInternalError_whenParamsMissing_inspectClass() {
-        val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"inspectClass","id":1}""")
-        val err = json.decodeFromString<RpcErrorResponse>(result.body)
-        assertEquals(-32603, err.error.code)
-    }
-
-    @Test
-    fun handle_returnsInternalError_whenParamsMissing_hookMethod() {
-        val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"hookMethod","id":1}""")
-        val err = json.decodeFromString<RpcErrorResponse>(result.body)
-        assertEquals(-32603, err.error.code)
-    }
-
-    // ─── handle — id types preserved ─────────────────────────────────────────
-
-    @Test
-    fun handle_preservesNumericId_inSuccessResponse() {
-        val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"healthCheck","id":42}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertEquals(42, res.id?.jsonPrimitive?.int)
-    }
-
-    @Test
-    fun handle_preservesStringId_inSuccessResponse() {
-        val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"healthCheck","id":"req-abc"}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertEquals("req-abc", res.id?.jsonPrimitive?.content)
+        val result = handler.handle("countInstances", """{"className":"com.example.MainActivity"}""")
+        assertEquals(200, result.statusCode)
+        assertFalse(result.body.contains("jsonrpc"))
+        assertFalse(result.body.contains("\"id\""))
+        assertTrue(result.body.contains("count"))
     }
 
     // ─── handle — each method happy path ─────────────────────────────────────
@@ -145,103 +120,108 @@ class RpcHandlerTest {
     @Test
     fun handle_countInstances_returnsCount() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"countInstances","params":{"className":"com.example.MainActivity"},"id":3}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertTrue(res.result.toString().contains("5"))
+        val result = handler.handle("countInstances", """{"className":"com.example.MainActivity"}""")
+        assertEquals(200, result.statusCode)
+        assertTrue(result.body.contains("5"))
     }
 
     @Test
     fun handle_countInstances_returnsZero_forUnknownClass() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"countInstances","params":{"className":"com.unknown.Class"},"id":3}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertTrue(res.result.toString().contains("0"))
+        val result = handler.handle("countInstances", """{"className":"com.unknown.Class"}""")
+        assertTrue(result.body.contains("0"))
     }
 
     @Test
     fun handle_inspectClass_returnsMethods() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"inspectClass","params":{"className":"com.example.MainActivity"},"id":4}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertTrue(res.result.toString().contains("methods"))
-        assertTrue(res.result.toString().contains("onCreate"))
+        val result = handler.handle("inspectClass", """{"className":"com.example.MainActivity"}""")
+        assertTrue(result.body.contains("methods"))
+        assertTrue(result.body.contains("onCreate"))
     }
 
     @Test
     fun handle_listInstances_returnsTotalCount() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"listInstances","params":{"className":"com.example.MainActivity"},"id":5}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertTrue(res.result.toString().contains("totalCount"))
+        val result = handler.handle("listInstances", """{"className":"com.example.MainActivity"}""")
+        assertTrue(result.body.contains("totalCount"))
     }
 
     @Test
     fun handle_inspectInstance_returnsAttributes() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"inspectInstance","params":{"className":"com.example.MainActivity","id":"123"},"id":6}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertTrue(res.result.toString().contains("attributes"))
-        assertTrue(res.result.toString().contains("mCount"))
+        val result = handler.handle("inspectInstance", """{"className":"com.example.MainActivity","id":"123"}""")
+        assertTrue(result.body.contains("attributes"))
+        assertTrue(result.body.contains("mCount"))
     }
 
     @Test
     fun handle_setFieldValue_returnsSuccessMessage() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"setFieldValue","params":{"className":"com.example.MainActivity","id":"123","fieldName":"mCount","type":"int","newValue":"10"},"id":7}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertTrue(res.result.toString().contains("Success"))
-        assertTrue(res.result.toString().contains("mCount"))
+        val result = handler.handle("setFieldValue", """{"className":"com.example.MainActivity","id":"123","fieldName":"mCount","type":"int","newValue":"10"}""")
+        assertTrue(result.body.contains("Success"))
+        assertTrue(result.body.contains("mCount"))
     }
 
     @Test
     fun handle_hookMethod_returnsHookedMessage() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"hookMethod","params":{"className":"com.example.MainActivity","methodSig":"onCreate(android.os.Bundle)"},"id":8}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertTrue(res.result.toString().contains("Hooked"))
+        val result = handler.handle("hookMethod", """{"className":"com.example.MainActivity","methodSig":"onCreate(android.os.Bundle)"}""")
+        assertTrue(result.body.contains("Hooked"))
     }
 
     @Test
     fun handle_setMethodImplementation_returnsReplacedMessage() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"setMethodImplementation","params":{"className":"com.example.MainActivity","methodSig":"onCreate(android.os.Bundle)","code":"return null;"},"id":10}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertTrue(res.result.toString().contains("Implementation replaced"))
+        val result = handler.handle("setMethodImplementation", """{"className":"com.example.MainActivity","methodSig":"onCreate(android.os.Bundle)","code":"return null;"}""")
+        assertTrue(result.body.contains("Implementation replaced"))
     }
 
     @Test
     fun handle_runOnce_returnsScriptExecuted() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"runOnce","params":{"className":"com.example.MainActivity","methodSig":"onCreate(android.os.Bundle)","code":"console.log('hi');"},"id":11}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertTrue(res.result.toString().contains("Script executed"))
+        val result = handler.handle("runOnce", """{"className":"com.example.MainActivity","methodSig":"onCreate(android.os.Bundle)","code":"console.log('hi');"}""")
+        assertTrue(result.body.contains("Script executed"))
     }
 
     @Test
     fun handle_getInstanceAddresses_returnsAddressList() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"getInstanceAddresses","params":{"className":"com.example.MainActivity"},"id":12}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertTrue(res.result.toString().contains("0x123"))
-        assertTrue(res.result.toString().contains("0x456"))
+        val result = handler.handle("getInstanceAddresses", """{"className":"com.example.MainActivity"}""")
+        assertTrue(result.body.contains("0x123"))
+        assertTrue(result.body.contains("0x456"))
+    }
+
+    @Test
+    fun handle_injectGadgetFromScratch_withoutBody_usesDefaults() {
+        val handler = RpcHandler(FakeFridaBridge())
+        val result = handler.handle("injectGadgetFromScratch")
+        val res = json.decodeFromString<JsonObject>(result.body)
+        assertEquals(200, result.statusCode)
+        assertTrue(res.containsKey("steps"))
     }
 
     @Test
     fun handle_injectGadgetFromScratch_returnsStatus() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"injectGadgetFromScratch","params":{"with_logs":true,"limit":100},"id":14}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertTrue(res.result.toString().contains("status"))
-        assertTrue(res.result.toString().contains("completed"))
+        val result = handler.handle("injectGadgetFromScratch", """{"with_logs":true,"limit":100}""")
+        assertTrue(result.body.contains("status"))
+        assertTrue(result.body.contains("completed"))
     }
 
     @Test
     fun handle_healthCheck_returnsOverall() {
         val handler = RpcHandler(FakeFridaBridge())
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"healthCheck","id":16}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertTrue(res.result.toString().contains("overall"))
-        assertTrue(res.result.toString().contains("ok"))
+        val result = handler.handle("healthCheck")
+        assertTrue(result.body.contains("overall"))
+        assertTrue(result.body.contains("ok"))
+    }
+
+    @Test
+    fun handle_getHookEvents_returnsEvents() {
+        val handler = RpcHandler(FakeFridaBridge())
+        val result = handler.handle("getHookEvents")
+        assertTrue(result.body.contains("events"))
     }
 
     // ─── handle — custom bridge response ──────────────────────────────────────
@@ -252,24 +232,22 @@ class RpcHandlerTest {
             HealthCheckResult("degraded", mapOf("bridge" to CheckResponse("error", "down")))
         })
         val handler = RpcHandler(bridge)
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"healthCheck","id":1}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertTrue(res.result.toString().contains("degraded"))
+        val result = handler.handle("healthCheck")
+        assertTrue(result.body.contains("degraded"))
     }
 
     @Test
     fun handle_countInstances_returnsCustomCount_whenBridgeOverridden() {
         val bridge = FakeFridaBridge(countInstancesFn = { _ -> CountInstancesResult(42) })
         val handler = RpcHandler(bridge)
-        val result = handler.handle("""{"jsonrpc":"2.0","method":"countInstances","params":{"className":"any.Class"},"id":1}""")
-        val res = json.decodeFromString<RpcResponse>(result.body)
-        assertTrue(res.result.toString().contains("42"))
+        val result = handler.handle("countInstances", """{"className":"any.Class"}""")
+        assertTrue(result.body.contains("42"))
     }
 
     // ─── handleStream ─────────────────────────────────────────────────────────
 
     @Test
-    fun handleStream_emitsChunks_forListClassesStream() {
+    fun handleStream_emitsPlainChunks_forListClassesStream() {
         val bridge = FakeFridaBridge(
             listClassesStreamFn = { _, onChunk, onComplete ->
                 runBlocking {
@@ -283,12 +261,15 @@ class RpcHandlerTest {
 
         runBlocking {
             handler.handleStream(
-                """{"jsonrpc":"2.0","method":"listClassesStream","params":{"search_param":"Main"},"id":1}"""
+                "listClassesStream",
+                """{"search_param":"Main"}"""
             ) { line -> emitted.add(line) }
         }
 
         assertTrue(emitted.isNotEmpty(), "Should emit at least one chunk or error message via stream")
         assertTrue(emitted.any { it.contains("com.example.MainActivity") }, "Should emit MainActivity")
+        assertTrue(emitted.none { it.contains("jsonrpc") }, "Chunks must not carry the JSON-RPC envelope")
+        assertTrue(emitted.any { it.contains("\"list\"") }, "Chunk must be the plain partial result")
     }
 
     @Test
@@ -296,7 +277,7 @@ class RpcHandlerTest {
         val handler = RpcHandler(FakeFridaBridge())
         val emitted = mutableListOf<String>()
         runBlocking {
-            handler.handleStream("not-json") { line -> emitted.add(line) }
+            handler.handleStream("listClassesStream", "not-json") { line -> emitted.add(line) }
         }
         assertEquals(1, emitted.size)
         assertTrue(emitted[0].contains("-32700"))
@@ -313,7 +294,8 @@ class RpcHandlerTest {
         val emitted = mutableListOf<String>()
         runBlocking {
             handler.handleStream(
-                """{"jsonrpc":"2.0","method":"listClassesStream","id":1}"""
+                "listClassesStream",
+                """{"search_param":"Main"}"""
             ) { line -> emitted.add(line) }
         }
         assertTrue(emitted.any { it.contains("-32603") })

--- a/src/commonTest/kotlin/rpc/ServerRoutingTest.kt
+++ b/src/commonTest/kotlin/rpc/ServerRoutingTest.kt
@@ -1,0 +1,74 @@
+package rpc
+
+import bridge.FakeFridaBridge
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import model.actions.result.ListClassesPartialResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import module
+
+/**
+ * HTTP smoke tests over the real routing tree produced by Server.module().
+ */
+class ServerRoutingTest {
+
+    @Test
+    fun v0ApiEndpoints_areReachable() = testApplication {
+        application { module(FakeFridaBridge()) }
+
+        val ping = client.get("/ping")
+        assertEquals(HttpStatusCode.OK, ping.status)
+
+        val health = client.post("/v0/api/health_check")
+        assertEquals(HttpStatusCode.OK, health.status)
+        assertTrue(health.bodyAsText().contains("overall"))
+
+        val count = client.post("/v0/api/count_instances") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"className":"com.example.MainActivity"}""")
+        }
+        assertEquals(HttpStatusCode.OK, count.status)
+        assertTrue(count.bodyAsText().contains("count"))
+
+        val invalid = client.post("/v0/api/count_instances") {
+            contentType(ContentType.Application.Json)
+            setBody("not-json")
+        }
+        assertEquals(HttpStatusCode.BadRequest, invalid.status)
+
+        val unknown = client.post("/v0/api/nope") {
+            contentType(ContentType.Application.Json)
+            setBody("{}")
+        }
+        assertEquals(HttpStatusCode.NotFound, unknown.status)
+    }
+
+    @Test
+    fun listClassesStream_returnsNdjson() = testApplication {
+        val bridge = FakeFridaBridge(
+            listClassesStreamFn = { _, onChunk, onComplete ->
+                runBlocking {
+                    onChunk(ListClassesPartialResult(listOf("com.example.MainActivity")))
+                }
+                onComplete()
+            }
+        )
+        application { module(bridge) }
+
+        val stream = client.post("/v0/api/list_classes_stream") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"search_param":"Main"}""")
+        }
+        assertEquals(HttpStatusCode.OK, stream.status)
+        assertTrue(stream.bodyAsText().contains("com.example.MainActivity"))
+    }
+}

--- a/src/unixMain/kotlin/Main.kt
+++ b/src/unixMain/kotlin/Main.kt
@@ -23,7 +23,7 @@ private fun runMcp() {
 
 private fun runRpc() {
     val bridge = NativeFridaBridge()
-    println("Starting Barbatos (HTTP JSON-RPC mode) on port 8080...")
+    println("Starting Barbatos (HTTP REST mode) on port 8080...")
     try {
         startServer(bridge)
     } catch (e: Exception) {
@@ -45,8 +45,9 @@ private fun printHelp() {
           mcp              Serve the Model Context Protocol (MCP) over Streamable HTTP
                            ->  http://127.0.0.1:8080/mcp
                            For MCP clients: opencode, Claude Desktop, Cursor, MCP Inspector.
-          rpc              Serve the HTTP JSON-RPC 2.0 API
-                           ->  POST http://127.0.0.1:8080/rpc   (also /ping, /docs, /openapi.yaml)
+          rpc              Serve the HTTP REST API (one endpoint per method)
+                           ->  POST http://127.0.0.1:8080/v0/api/<snake_case>
+                           (also GET /ping, /docs, /openapi.yaml)
                            For curl, scripts and REST-based tooling.
           help | --help | -h
                            Show this help
@@ -55,8 +56,6 @@ private fun printHelp() {
           * A device must be connected via adb with a debuggable app in the foreground.
           * Both modes listen on 127.0.0.1:8080 and are mutually exclusive
             (starting one kills whatever occupies the port).
-          * Inspect and hook tools need a Frida session first: call
-            injectGadgetFromScratch before using them.
         """.trimIndent()
     )
 }

--- a/web/openapi.yaml
+++ b/web/openapi.yaml
@@ -1,13 +1,13 @@
 openapi: 3.0.3
 info:
-  title: Barbatos JSON-RPC Bridge API
-  version: 2.0.0-alpha02
+  title: Barbatos REST API
+  version: 2.0.0-alpha03
   description: |
     HTTP transport of the barbatos bridge. The binary drives a Frida agent injected into
-    an Android process and exposes it over JSON-RPC 2.0.
+    an Android process and exposes it over plain HTTP endpoints.
 
-    Started with `barbatos` (no arguments) — binds `127.0.0.1:8080` and kills whatever
-    already holds the port. There is no authentication: the server is loopback-only.
+    Started with `barbatos rpc` (no arguments otherwise) — binds `127.0.0.1:8080` and kills
+    whatever already holds the port. There is no authentication: the server is loopback-only.
 
     This spec is served by the bridge itself: **<http://127.0.0.1:8080/docs>** renders it,
     `GET /openapi.yaml` returns it raw. Both are embedded in the binary at build time, so
@@ -17,57 +17,54 @@ info:
 
     | Transport | How to start | Surface |
     |---|---|---|
-    | HTTP (this document) | `barbatos rpc` | `GET /ping`, `POST /rpc`, `GET /docs`, `GET /openapi.yaml` |
+    | HTTP (this document) | `barbatos rpc` | `GET /ping`, `POST /v0/api/*`, `GET /docs`, `GET /openapi.yaml` |
     | MCP over Streamable HTTP | `barbatos mcp` | `initialize`, `tools/list`, `tools/call`, `prompts/list`, `resources/list` |
     | Help | `barbatos` | Prints usage and an overview of both transports |
 
-    Both transports dispatch into the same `RpcHandler`, so every method
-    below is also reachable as an MCP tool. `listClassesStream` streams its chunks
-    over HTTP (`application/x-ndjson`) and, over MCP, returns the accumulated chunk
-    lines as the `tools/call` result. `tools/list` returns each method as
+    Both transports dispatch into the same `RpcHandler`, so every endpoint below is also
+    reachable as an MCP tool (camelCase tool name). `listClassesStream` streams its chunks
+    over HTTP (`application/x-ndjson`) and, over MCP, returns the accumulated chunk lines
+    as the `tools/call` result. `tools/list` returns each method as
     `{name, description, inputSchema}`, where `inputSchema` is the JSON Schema generated
     from the corresponding `*Params` class.
 
-    ### JSON-RPC method contract
+    ### Endpoint contract
 
-    Every method is invoked via `POST /rpc`. `params` keys are the wire names
-    (`@SerialName`), which differ from the Kotlin property names where noted.
+    Every endpoint is `POST /v0/api/<snake_case method>` and takes the params object as
+    the raw JSON body (no envelope). The response is the plain result object. Parameterless
+    endpoints accept an empty body.
 
-    | Method | Parameters schema | Required params | Result schema |
+    | Endpoint | Parameters schema | Required params | Result schema |
     |---|---|---|---|
-    | **debugPing** | (none) | — | String — `"pong"` |
-    | **testRpc** | (none) | — | String — `"ok"` |
-    | **healthCheck** | (none) | — | `HealthCheckResult` |
-    | **getHookEvents** | (none) | — | `HookEventsResult` |
-    | **countInstances** | `CountInstancesParams` | `className` | `CountInstancesResult` |
-    | **inspectClass** | `InspectClassParams` | `className` | `InspectClassResult` |
-    | **listInstances** | `ListInstancesParams` | `className` | `ListInstancesResult` |
-    | **getInstanceAddresses** | `GetInstanceAddressesParams` | `className` | `GetInstanceAddressesResult` |
-    | **inspectInstance** | `InspectInstanceParams` | `className`, `id` | `InspectInstanceResult` |
-    | **setFieldValue** | `SetFieldValueParams` | all | `StatusResult` |
-    | **hookMethod** | `HookParams` | `className`, `methodSig` | `StatusResult` |
-    | **setMethodImplementation** | `SetMethodImplementationParams` | all | `StatusResult` |
-    | **runOnce** | `RunOnceParams` | all | `StatusResult` |
-    | **prepareEnvironment** | `PrepareEnvParams` | `package_name` | `StatusResult` |
-    | **injectGadgetFromScratch** | `InjectGadgetParams` | (none) | `InjectGadgetResult` |
-    | **injectJdwp** | `InjectJdwpParams` | all | `StatusResult` |
-    | **listClassesStream** | `ListClassesParams` | (none) | NDJSON stream — see `POST /rpc` |
+    | **/v0/api/count_instances** | `CountInstancesParams` | `className` | `CountInstancesResult` |
+    | **/v0/api/inspect_class** | `InspectClassParams` | `className` | `InspectClassResult` |
+    | **/v0/api/list_instances** | `ListInstancesParams` | `className` | `ListInstancesResult` |
+    | **/v0/api/get_instance_addresses** | `GetInstanceAddressesParams` | `className` | `GetInstanceAddressesResult` |
+    | **/v0/api/inspect_instance** | `InspectInstanceParams` | `className`, `id` | `InspectInstanceResult` |
+    | **/v0/api/set_field_value** | `SetFieldValueParams` | all | `StatusResult` |
+    | **/v0/api/hook_method** | `HookParams` | `className`, `methodSig` | `StatusResult` |
+    | **/v0/api/set_method_implementation** | `SetMethodImplementationParams` | all | `StatusResult` |
+    | **/v0/api/run_once** | `RunOnceParams` | all | `StatusResult` |
+    | **/v0/api/get_hook_events** | (none) | — | `HookEventsResult` |
+    | **/v0/api/inject_gadget_from_scratch** | `InjectGadgetParams` | (none) | `InjectGadgetResult` |
+    | **/v0/api/health_check** | (none) | — | `HealthCheckResult` |
+    | **/v0/api/list_classes_stream** | `ListClassesParams` | (none) | NDJSON stream — see below |
+
+    Params keys are the wire names (`@SerialName`), which differ from the Kotlin property
+    names where noted.
 
     ### Session lifecycle
 
-    Call **injectGadgetFromScratch** first — it detects the foreground app, picks the
-    rooted (frida-server over USB) or debuggable (Gadget over JDWP) path, and attaches.
-    Every method other than `healthCheck` needs that active session; without one the
-    bridge answers `"error: Frida script not loaded."`.
-
-    `prepareEnvironment` and `injectJdwp` are the low-level steps of that same flow and
-    are exposed for manual recovery.
+    Call **POST /v0/api/inject_gadget_from_scratch** first — it detects the foreground app,
+    picks the rooted (frida-server over USB) or debuggable (Gadget over JDWP) path, and
+    attaches. Every endpoint other than `health_check` needs that active session; without
+    one the bridge answers `"error: Frida script not loaded."`.
 
     ### Error handling
 
-    `POST /rpc` always answers `200`, including for errors — check for an `error` member
-    in the body. Codes: `-32700` malformed JSON, `-32601` unknown method
-    (the message contains `not found`), `-32603` anything thrown by the bridge.
+    Non-success responses carry a body of the shape `{"error":{"code":<int>,"message":...}}`
+    with a real HTTP status: `400` malformed body (`-32700`), `404` unknown endpoint
+    (`-32601`), `500` anything thrown by the bridge (`-32603`).
 
 servers:
   - url: http://127.0.0.1:8080
@@ -78,7 +75,7 @@ paths:
       summary: Liveness probe
       description: |
         Verifies the HTTP server is up. Does not touch the Frida session — it answers
-        even when no injection has happened yet. Use `healthCheck` to probe ADB, root
+        even when no injection has happened yet. Use `health_check` to probe ADB, root
         status and session state.
       responses:
         '200':
@@ -92,253 +89,324 @@ paths:
                   status:
                     type: string
                     example: pong
-  /rpc:
+  /docs:
+    get:
+      summary: Swagger UI
+      responses:
+        '200':
+          description: HTML docs page rendering this spec
+  /openapi.yaml:
+    get:
+      summary: Raw OpenAPI spec
+      responses:
+        '200':
+          description: This spec as embedded in the binary
+  /v0/api/health_check:
     post:
-      summary: JSON-RPC 2.0 endpoint
+      summary: healthCheck — probe ADB, root, frontmost app and session
       description: |
-        Single entry point for all debugger operations.
-
-        When `method` is `listClassesStream` the response is **NDJSON**
-        (`application/x-ndjson`): one `RpcResponse` per line, each carrying a
-        `ListClassesPartialResult` chunk in `result`, sharing the request `id`. The
-        stream ends when the connection closes; there is no terminating sentinel. A
-        failure mid-stream emits a single `RpcErrorResponse` line.
-
-        Every other method returns a single `application/json` object.
+        Callable without an active session. Returns `overall` ("ok" or "degraded") plus a
+        `checks` map covering adb, android_root, android_frontmost_app, frida_device,
+        frida_connection and session.
+      responses:
+        '200':
+          description: Health check result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthCheckResult'
+              examples:
+                ok:
+                  value:
+                    overall: ok
+                    checks:
+                      adb:
+                        status: ok
+                        message: adb available
+                      android_root:
+                        status: skipped
+                        message: Not checked
+                    recommendation: null
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /v0/api/inject_gadget_from_scratch:
+    post:
+      summary: injectGadgetFromScratch — start a session (call this first)
+      description: |
+        Detects the foreground app, picks the rooted or debuggable injection path and
+        attaches. Every field of the body is optional.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InjectGadgetParams'
+            examples:
+              default:
+                value:
+                  with_logs: true
+                  limit: 100
+                  serial: null
+      responses:
+        '200':
+          description: Injection outcome with per-step status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InjectGadgetResult'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /v0/api/count_instances:
+    post:
+      summary: countInstances — how many live instances on the heap?
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RpcRequest'
+              $ref: '#/components/schemas/CountInstancesParams'
             examples:
-              injectGadgetFromScratch:
-                summary: injectGadgetFromScratch — start a session (call this first)
+              default:
                 value:
-                  jsonrpc: "2.0"
-                  id: 1
-                  method: injectGadgetFromScratch
-                  params:
-                    with_logs: true
-                    limit: 100
-                    serial: null
-              healthCheck:
-                summary: healthCheck — probe ADB, root, frontmost app and session
-                value:
-                  jsonrpc: "2.0"
-                  id: 2
-                  method: healthCheck
-                  params: {}
-              debugPing:
-                summary: debugPing — is the injected agent alive?
-                value:
-                  jsonrpc: "2.0"
-                  id: 3
-                  method: debugPing
-                  params: {}
-              testRpc:
-                summary: testRpc — is the JSON-RPC channel to the agent working?
-                value:
-                  jsonrpc: "2.0"
-                  id: 4
-                  method: testRpc
-                  params: {}
-              listClassesStream:
-                summary: listClassesStream — search loaded classes (NDJSON response)
-                value:
-                  jsonrpc: "2.0"
-                  id: 5
-                  method: listClassesStream
-                  params:
-                    search_param: MyClass
-                    app_package: com.example.myapp
-                    offset: 0
-                    limit: 200
-              inspectClass:
-                summary: inspectClass — list a class's fields and methods
-                value:
-                  jsonrpc: "2.0"
-                  id: 6
-                  method: inspectClass
-                  params:
-                    className: com.example.MyClass
-              countInstances:
-                summary: countInstances — how many live instances on the heap?
-                value:
-                  jsonrpc: "2.0"
-                  id: 7
-                  method: countInstances
-                  params:
-                    className: com.example.MyClass
-              listInstances:
-                summary: listInstances — get instance ids for a class
-                value:
-                  jsonrpc: "2.0"
-                  id: 8
-                  method: listInstances
-                  params:
-                    className: com.example.MyClass
-              getInstanceAddresses:
-                summary: getInstanceAddresses — memory addresses of live instances
-                value:
-                  jsonrpc: "2.0"
-                  id: 9
-                  method: getInstanceAddresses
-                  params:
-                    className: com.example.MyClass
-              inspectInstance:
-                summary: inspectInstance — read a live object's field values
-                value:
-                  jsonrpc: "2.0"
-                  id: 10
-                  method: inspectInstance
-                  params:
-                    className: com.example.MyClass
-                    id: "0"
-                    offset: 0
-                    limit: 50
-              setFieldValue:
-                summary: setFieldValue — mutate a field at runtime
-                value:
-                  jsonrpc: "2.0"
-                  id: 11
-                  method: setFieldValue
-                  params:
-                    className: com.example.MyClass
-                    id: "0"
-                    fieldName: myField
-                    type: String
-                    newValue: patched
-              hookMethod:
-                summary: hookMethod — record every call to a method
-                value:
-                  jsonrpc: "2.0"
-                  id: 12
-                  method: hookMethod
-                  params:
-                    className: com.example.MyClass
-                    methodSig: myMethod
-              getHookEvents:
-                summary: getHookEvents — drain the calls recorded so far
-                value:
-                  jsonrpc: "2.0"
-                  id: 13
-                  method: getHookEvents
-                  params: {}
-              setMethodImplementation:
-                summary: setMethodImplementation — replace a method for the session
-                value:
-                  jsonrpc: "2.0"
-                  id: 14
-                  method: setMethodImplementation
-                  params:
-                    className: com.example.MyClass
-                    methodSig: myMethod
-                    code: "console.log('[barbatos] intercepted', args); return true;"
-              runOnce:
-                summary: runOnce — replace a method for a single call, then restore
-                value:
-                  jsonrpc: "2.0"
-                  id: 15
-                  method: runOnce
-                  params:
-                    className: com.example.MyClass
-                    methodSig: myMethod
-                    code: "console.log('[barbatos] one-shot', args); return true;"
-              prepareEnvironment:
-                summary: prepareEnvironment — attach manually (low-level)
-                value:
-                  jsonrpc: "2.0"
-                  id: 16
-                  method: prepareEnvironment
-                  params:
-                    pid: null
-                    package_name: com.example.myapp
-                    target: Gadget
-                    serial: null
-              injectJdwp:
-                summary: injectJdwp — inject the Gadget over JDWP (low-level)
-                value:
-                  jsonrpc: "2.0"
-                  id: 17
-                  method: injectJdwp
-                  params:
-                    target: 127.0.0.1
-                    port: 5005
-                    package_name: com.example.myapp
+                  className: com.example.MyClass
       responses:
         '200':
-          description: |
-            JSON-RPC response (success or error). Errors are also returned with status
-            `200` — inspect the body.
-
-            `application/x-ndjson` is returned only for `listClassesStream`: one
-            `RpcResponse` per line, not a JSON array.
+          description: Instance count
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/RpcResponse'
-                  - $ref: '#/components/schemas/RpcErrorResponse'
+                $ref: '#/components/schemas/CountInstancesResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /v0/api/inspect_class:
+    post:
+      summary: inspectClass — list a class's fields and methods
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InspectClassParams'
+      responses:
+        '200':
+          description: Class structure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InspectClassResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /v0/api/list_instances:
+    post:
+      summary: listInstances — get instance ids for a class
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListInstancesParams'
+      responses:
+        '200':
+          description: Live instances
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListInstancesResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /v0/api/get_instance_addresses:
+    post:
+      summary: getInstanceAddresses — memory addresses of live instances
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetInstanceAddressesParams'
+      responses:
+        '200':
+          description: Addresses
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetInstanceAddressesResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /v0/api/inspect_instance:
+    post:
+      summary: inspectInstance — read a live object's field values
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InspectInstanceParams'
+      responses:
+        '200':
+          description: Field values with pagination
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InspectInstanceResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /v0/api/set_field_value:
+    post:
+      summary: setFieldValue — mutate a field at runtime
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetFieldValueParams'
+      responses:
+        '200':
+          description: Status result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /v0/api/hook_method:
+    post:
+      summary: hookMethod — record every call to a method
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HookParams'
+      responses:
+        '200':
+          description: Status result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /v0/api/set_method_implementation:
+    post:
+      summary: setMethodImplementation — replace a method for the session
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetMethodImplementationParams'
+      responses:
+        '200':
+          description: Status result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /v0/api/run_once:
+    post:
+      summary: runOnce — replace a method for a single call, then restore
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunOnceParams'
+      responses:
+        '200':
+          description: Status result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /v0/api/get_hook_events:
+    post:
+      summary: getHookEvents — drain the calls recorded so far
+      description: Takes no parameters. The body may be empty.
+      responses:
+        '200':
+          description: Hook events accumulated since the last call
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HookEventsResult'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /v0/api/list_classes_stream:
+    post:
+      summary: listClassesStream — search loaded classes (NDJSON response)
+      description: |
+        Streams matching class names as NDJSON (`application/x-ndjson`): one plain
+        `ListClassesPartialResult` object (`{"list": [...]}`) per line. The stream ends
+        when the connection closes; there is no terminating sentinel. A failure mid-stream
+        emits a single `ApiError` line.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListClassesParams'
+            examples:
+              default:
+                value:
+                  search_param: MyClass
+                  app_package: com.example.myapp
+                  offset: 0
+                  limit: 200
+      responses:
+        '200':
+          description: NDJSON stream of chunks, one per line
+          content:
             application/x-ndjson:
               schema:
-                $ref: '#/components/schemas/RpcResponse'
+                $ref: '#/components/schemas/ListClassesPartialResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
 components:
+  responses:
+    BadRequest:
+      description: Malformed JSON body
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
+    NotFound:
+      description: Unknown endpoint
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
+    InternalError:
+      description: The bridge threw while processing the request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
   schemas:
-    # -------------------------
-    # JSON-RPC base envelopes
-    # -------------------------
-    RpcRequest:
-      type: object
-      required: [method]
-      properties:
-        jsonrpc:
-          type: string
-          default: "2.0"
-        id:
-          description: |
-            Echoed back on the response. Any JSON value; omit it only if you do not
-            need to correlate the reply.
-          example: 1
-        method:
-          type: string
-          description: Name of the method to invoke.
-        params:
-          type: object
-          description: |
-            Method-specific parameters (see the contract table). Omit for methods that
-            take none; omitting it for a method that requires params fails with
-            `Missing params` (`-32603`).
-      description: Unknown members are ignored.
-
-    RpcResponse:
-      type: object
-      required: [jsonrpc, result, id]
-      properties:
-        jsonrpc:
-          type: string
-          example: "2.0"
-        id:
-          description: The `id` from the request, or `null`.
-          example: 1
-        result:
-          description: Result of the invoked method (see the contract table).
-
-    RpcErrorResponse:
-      type: object
-      required: [jsonrpc, error, id]
-      properties:
-        jsonrpc:
-          type: string
-          example: "2.0"
-        id:
-          description: The `id` from the request, or `null` when it could not be parsed.
-          example: 1
-          nullable: true
-        error:
-          $ref: '#/components/schemas/JsonRpcError'
-
-    JsonRpcError:
+    ApiError:
       type: object
       required: [code, message]
       properties:
@@ -346,19 +414,16 @@ components:
           type: integer
           enum: [-32700, -32601, -32603]
           description: |
-            `-32700` parse error, `-32601` method not found, `-32603` internal error.
+            `-32700` malformed body, `-32601` unknown endpoint, `-32603` internal error.
         message:
           type: string
-        data:
-          description: Always absent on this bridge.
-          nullable: true
 
     # -------------------------
     # Parameter schemas
     # -------------------------
     ListClassesParams:
       type: object
-      description: Used only by `listClassesStream`. Every field has a default.
+      description: Used only by `list_classes_stream`. Every field has a default.
       properties:
         search_param:
           type: string
@@ -412,7 +477,7 @@ components:
           type: string
         id:
           type: string
-          description: Instance id returned by `listInstances`.
+          description: Instance id returned by `list_instances`.
         offset:
           type: integer
           default: 0
@@ -428,7 +493,7 @@ components:
           type: string
         id:
           type: string
-          description: Instance id returned by `listInstances`.
+          description: Instance id returned by `list_instances`.
         fieldName:
           type: string
         type:
@@ -478,29 +543,6 @@ components:
             Same contract as `SetMethodImplementationParams.code`, but the original
             implementation is restored after the first call.
 
-    PrepareEnvParams:
-      type: object
-      required: [package_name]
-      properties:
-        pid:
-          type: integer
-          nullable: true
-          description: Target pid. When omitted the process is resolved by `package_name`.
-        package_name:
-          type: string
-        target:
-          type: string
-          nullable: true
-          description: |
-            `Gadget` or `127.0.0.1` connects to a remote Frida Gadget over TCP on port
-            27042 (the non-rooted/debuggable path). Otherwise attaches over USB.
-        serial:
-          type: string
-          nullable: true
-          description: |
-            Device serial from `adb devices`. Required when several devices are
-            connected, otherwise the wrong one may be picked.
-
     InjectGadgetParams:
       type: object
       description: Every field is optional.
@@ -516,29 +558,14 @@ components:
           nullable: true
           description: Device serial from `adb devices`.
 
-    InjectJdwpParams:
-      type: object
-      required: [target, port, package_name]
-      properties:
-        target:
-          type: string
-          description: Host address.
-          example: 127.0.0.1
-        port:
-          type: integer
-          description: Forwarded JDWP port.
-          example: 5005
-        package_name:
-          type: string
-
     # -------------------------
     # Result schemas
     # -------------------------
     StatusResult:
       type: object
       description: |
-        Shared shape of `setFieldValue`, `hookMethod`, `setMethodImplementation`,
-        `runOnce`, `prepareEnvironment` and `injectJdwp`.
+        Shared shape of `set_field_value`, `hook_method`, `set_method_implementation` and
+        `run_once`.
       required: [status]
       properties:
         status:
@@ -592,7 +619,7 @@ components:
       properties:
         id:
           type: string
-          description: Pass this to `inspectInstance` and `setFieldValue`.
+          description: Pass this to `inspect_instance` and `set_field_value`.
         handle:
           type: string
         summary:
@@ -635,7 +662,7 @@ components:
         childId:
           type: string
           nullable: true
-          description: Pass to `inspectInstance` to drill into a nested object.
+          description: Pass to `inspect_instance` to drill into a nested object.
         childClassName:
           type: string
           nullable: true
@@ -649,7 +676,7 @@ components:
     HookEventsResult:
       type: object
       description: |
-        Drains the events recorded by `hookMethod` since the previous call. Empty until
+        Drains the events recorded by `hook_method` since the previous call. Empty until
         a hooked method is invoked.
       required: [events]
       properties:
@@ -766,7 +793,7 @@ components:
     ListClassesPartialResult:
       type: object
       description: |
-        One NDJSON chunk of `listClassesStream`, carried in `RpcResponse.result`.
+        One NDJSON chunk of `list_classes_stream`.
       required: [list]
       properties:
         list:


### PR DESCRIPTION
Replaces the single JSON-RPC 2.0 endpoint (`POST /rpc`) with one REST endpoint per method under `/v0/api/<snake_case>`, dropping the `jsonrpc`/`id` envelope on both request and response.

## What changed
- Each method is now `POST /v0/api/<snake_case>` (e.g. `injectGadgetFromScratch` -> `POST /v0/api/inject_gadget_from_scratch`).
- Request body is the params object directly; the response is the plain result (no `jsonrpc`, `id`, `result` wrapper).
- Errors use real HTTP statuses (`400` malformed body, `404` unknown endpoint, `500` internal error) with `{"error":{"code","message"}}` bodies; JSON-RPC error codes kept for traceability.
- `listClassesStream` still streams NDJSON, but each line is the plain partial result instead of a response envelope.
- Doc-only methods with no dispatch in the handler (`debugPing`, `testRpc`, `prepareEnvironment`, `injectJdwp`) removed from the spec and from the Gradle `rpc*` task list.
- MCP transport unchanged (tool names stay camelCase, still dispatch through the same `processMethod`).

## Files
- `rpc/RpcHandler.kt`: `camelToSnake`, route table, `handle(method, body)`, plain NDJSON stream.
- `Server.kt`: per-endpoint routes derived from `RpcHandler.tools` + `404` fallback; `/rpc` removed.
- `model/rpc/RpcBase.kt`: JSON-RPC envelope models replaced by `ApiError`/`ApiErrorResponse`.
- `web/openapi.yaml`: rewritten for the REST surface (`2.0.0-alpha03`).
- Tests: `RpcHandlerTest` reworked, `McpServerTest` chunk assertion updated, new `ServerRoutingTest`.

## Validation
- `./gradlew macosArm64Test` green (47 tests).
- Linux targets compile (`compileKotlinLinuxX64`/).
- `linkReleaseExecutableMacosArm64` ok.
- Live smoke: `/ping`, `/v0/api/health_check`, 400/404 paths, removed `/rpc`.
